### PR TITLE
roles: Add system/sshd

### DIFF
--- a/playbooks/hosts/anvil.yml
+++ b/playbooks/hosts/anvil.yml
@@ -6,5 +6,5 @@
   roles:
     - { role: system/firewalld, tags: ['firewalld', 'system'] }
     - { role: system/selinux, tags: ['selinux', 'system'] }
-    # - { role: system/sshd, tags: ['sshd', 'system'] }
+    - { role: system/sshd, tags: ['sshd', 'system'] }
     - { role: anvil.ccmc.pw, tags: ['anvil', 'apps'] }

--- a/roles/system/sshd/handlers/main.yml
+++ b/roles/system/sshd/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart sshd
+  service:
+    name: sshd
+    state: restarted

--- a/roles/system/sshd/tasks/main.yml
+++ b/roles/system/sshd/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: create SSH config directories for running user (~/.ssh)
+  file:
+    state: directory
+    path: "{{ ansible_user_dir }}/.ssh"
+    mode: 0700
+    owner: "{{ ansible_user_id }}"
+    setype: ssh_home_t
+    seuser: system_u
+
+- name: add SSH public key to authorized_keys for running user (~/.ssh/authorized_keys)
+  template:
+    src: authorized_keys
+    dest: "{{ ansible_user_dir }}/.ssh/authorized_keys"
+    mode: 0400
+    owner: "{{ ansible_user_id }}"
+    setype: ssh_home_t
+    seuser: system_u
+
+- name: push /etc/ssh/sshd_config
+  template:
+    src: sshd_config
+    dest: "/etc/ssh/sshd_config"
+    mode: 0600
+    setype: etc_t
+    seuser: system_u
+  notify: restart sshd

--- a/roles/system/sshd/templates/authorized_keys
+++ b/roles/system/sshd/templates/authorized_keys
@@ -1,0 +1,7 @@
+{% if ansible_user_id == "blaster" %}
+    {{ sshd.authentication.authorized_keys.blaster }}
+{% elif ansible_user_id == "jmw" %}
+    {{ sshd.authentication.authorized_keys.jmw }}
+{% elif ansible_user_id == "jwf" %}
+    {{ sshd.authentication.authorized_keys.jwf }}
+{% endif %}

--- a/roles/system/sshd/templates/sshd_config
+++ b/roles/system/sshd/templates/sshd_config
@@ -1,0 +1,154 @@
+###############################################################################
+#                                                                             #
+#           THIS FILE IS MANAGED BY ANSIBLE! CHANGES ARE OVERWRITTEN.         #
+#                   https://github.com/jwflory/infrastructure                 #
+#                                                                             #
+###############################################################################
+#      $OpenBSD: sshd_config,v 1.103 2018/04/09 20:41:22 tj Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+# If you want to change the port on a SELinux system, you have to tell
+# SELinux about this change.
+# semanage port -a -t ssh_port_t -p tcp #PORTNUMBER
+#
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# System-wide Crypto policy:
+# This system is following system-wide crypto policy. The changes to
+# Ciphers, MACs, KexAlgoritms and GSSAPIKexAlgorithsm will not have any
+# effect here. They will be overridden by command-line options passed on
+# the server start up.
+# To opt out, uncomment a line with redefinition of  CRYPTO_POLICY=
+# variable in  /etc/sysconfig/sshd  to overwrite the policy.
+# For more information, see manual page for update-crypto-policies(8).
+
+# Logging
+#SyslogFacility AUTH
+SyslogFacility AUTHPRIV
+#LogLevel INFO
+
+# Authentication:
+AllowUsers {{ sshd.authentication.allow_users }}
+#LoginGraceTime 2m
+PermitRootLogin {{ sshd.authentication.permit_root_login }}
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+PasswordAuthentication {{ sshd.authentication.password_authentication }}
+
+# Change to no to disable s/key passwords
+#ChallengeResponseAuthentication yes
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+#KerberosUseKuserok yes
+
+# GSSAPI options
+GSSAPIAuthentication no
+GSSAPICleanupCredentials no
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+#GSSAPIEnablek5users no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+# WARNING: 'UsePAM no' is not supported in Fedora and may cause several
+# problems.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+
+# It is recommended to use pam_motd in /etc/pam.d/sshd instead of PrintMotd,
+# as it is more configurable and versatile than the built-in version.
+PrintMotd no
+
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Accept locale-related environment variables
+AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
+AcceptEnv XMODIFIERS
+
+# override default of no subsystems
+Subsystem	sftp	/usr/libexec/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/roles/system/sshd/vars/main.yml
+++ b/roles/system/sshd/vars/main.yml
@@ -1,0 +1,15 @@
+---
+# Notes:
+#   1. Make sure allow_users is set before running this role.
+#   2. Wrap any "no" or "yes" strings in quotes so they are not reinterpreted
+#      by Ansible as True/False
+
+sshd:
+  authentication:
+    allow_users: "jwf jmw blaster"
+    authorized_keys:
+      jwf: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHr+JccK7HWKuI9GfjwuAzfeYW1en5ZdZZNxQh1bNGc/ justin@jwf.io"
+      jmw: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBJLsJwv4+i5fmcSxDfCfbM1/u2tojAKJBFYpl0fRRGW jalen.wayt@gmail.com"
+      blaster: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHRtb+S630XSGV3/NqX63QA4FQA6nj0dGgy1P/hnm81M corbin.wilkins1@gmail.com"
+    password_authentication: "no"
+    permit_root_login: "no"


### PR DESCRIPTION
This commit adds a new role to manage the SSHD daemon. This hardens the
SSH server policy to whitelist specific, authorized users. It also sets
up SSH key authentication for each user.