### PR TITLE
ci: Initial commit, add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+---
+os: linux
+dist: bionic
+
+language: python
+python: "3.8"
+cache: pip
+install:
+  - pipenv lock --dev --requirements > /tmp/requirements.txt
+  - pip install -r /tmp/requirements.txt
+script:
+  - yamllint -c .yamllint .
+  - ansible-lint -x 403 playbooks/master.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,4 @@
+extends: relaxed
+
+rules:
+  line-length: disable

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ CrystalCraftMC Infrastructure
 =============================
 
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)
+[![Build Status](https://travis-ci.org/CrystalCraftMC/infrastructure.svg?branch=master)](https://travis-ci.org/CrystalCraftMC/infrastructure)
 
 Set of scripts, Ansible playbooks/roles, and other tools to automate and manage CrystalCraftMC infrastructure
 

--- a/playbooks/master.yml
+++ b/playbooks/master.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: hosts/anvil.yml


### PR DESCRIPTION
This commit sets up a basic Continuous Integration test suite. It runs a
YAML linter and an Ansible Playbook linter to catch common mistakes. The
results of the CI tests are reported back in a Pull Request or the
branch status.

This will make it easier to validate and test new changes for common
mistakes and errors.