### PR TITLE
spigot: Convert spigot-server directory to variable

### DIFF
--- a/roles/spigot/defaults/main.yml
+++ b/roles/spigot/defaults/main.yml
@@ -6,4 +6,4 @@ linux:
 spigot:
   jar_path: "/usr/games/spigot/spigot.jar"
   version: "1.16.2"
-server_jar_path: "/var/games/spigot-server/spigot.jar"
+server_path: "/var/games/spigot-server"

--- a/roles/spigot/tasks/server.yml
+++ b/roles/spigot/tasks/server.yml
@@ -1,18 +1,18 @@
 ---
-- name: create /var/games/spigot-server/ directory
+- name: create spigot-server directory
   file:
-    path: /var/games/spigot-server/
+    path: "{{ server_path }}"
     state: directory
     owner: "{{ linux.mc_user }}"
     group: "{{ linux.mc_user }}"
     mode: 0775
     seuser: system_u
 
-- name: copy spigot.jar_path to server_jar_path
+- name: copy spigot.jar_path to server_path
   copy:
     src: "{{ spigot.jar_path }}"
     remote_src: yes
-    dest: "{{ server_jar_path }}"
+    dest: "{{ server_path }}/spigot.jar"
     owner: "{{ linux.mc_user }}"
     group: "{{ linux.mc_user }}"
     mode: 0744

--- a/roles/spigot/tasks/user-management.yml
+++ b/roles/spigot/tasks/user-management.yml
@@ -4,7 +4,7 @@
     name: "{{ linux.mc_user }}"
     comment: "system user for Spigot Minecraft servers - do not use"
     create_home: no
-    home: /var/games/spigot-server
+    home: "{{ server_path }}"
     system: yes
 
 - name: append spigot-admin group to admin users


### PR DESCRIPTION
This commit changes `/var/games/spigot-server/` directory into a
variable. This makes it easier to manage the path for the Spigot server,
and will also be used in a subsequent change that fixes the issue with
the server running in the root directory.

But this is just the prep work for the real fix!