### PR TITLE
spigot: Set WorkingDirectory to avoid perms problems

### DIFF
--- a/roles/spigot/templates/spigot.service
+++ b/roles/spigot/templates/spigot.service
@@ -7,7 +7,8 @@ After=multi-user.target
 Type=simple
 User={{ linux.mc_user }}
 Group={{ linux.mc_user }}
-ExecStart=+/usr/bin/java -Xms{{ linux.mem_usage }} -Xmx{{ linux.mem_usage }} -Dcom.mojang.eula.agree=true -jar {{ server_jar_path }} nogui
+WorkingDirectory={{ server_path }}
+ExecStart=+/usr/bin/java -Xms{{ linux.mem_usage }} -Xmx{{ linux.mem_usage }} -Dcom.mojang.eula.agree=true -jar spigot.jar nogui
 Restart=on-failure
 RestartSec=15
 


### PR DESCRIPTION
This commit adds a `WorkingDirectory` line into the systemd service file
used for starting, stopping, and restarting the server. This was a
mistake I made while setting up the systemd service.

Originally, the systemd service had the full path to the `spigot.jar` in
the `ExecStart` statement. But that caused the process to be started
from the root directory, meaning all of the server files and data were
being written to the root directory. Oh no!

So, this sets `WorkingDirectory` to the path of the Spigot server, and
it makes the path to `spigot.jar` local. So this way, the server should
never start if it is not in the right directory.

I tested this change on `anvil.ccmc.pw` and I confirmed that it worked.
It also picked up the plugins I had uploaded previously. So, I think
this will get everything working and in good shape! Sorry about the
bumpy road in the beginning.