### PR TITLE
nginx: Fix broken cert path for TLS certificates

### DIFF
--- a/roles/nginx/templates/nginx.conf
+++ b/roles/nginx/templates/nginx.conf
@@ -51,8 +51,8 @@ http {
 
         root /var/www/html;
 
-        ssl_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/{{ ansible_host }}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/{{ ansible_host }}/privkey.pem;
         ssl_session_timeout 1d;
         ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
         ssl_session_tickets off;
@@ -73,7 +73,7 @@ http {
         ssl_stapling_verify on;
 
         # verify chain of trust of OCSP response using Root CA and Intermediate certs
-        ssl_trusted_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/chain.pem;
+        ssl_trusted_certificate /etc/letsencrypt/live/{{ ansible_host }}/chain.pem;
 
         # replace with the IP address of your resolver
         resolver 1.1.1.1;


### PR DESCRIPTION
This commit fixes a bug in the nginx config by changing the Ansible
variable used for the server hostname.

Previously, `inventory_hostname` was used, but that evaluates to `anvil`
per the `inventory/inventory` file. This commit changes
`inventory_hostname` to `ansible_host`, which evaluates to the fully-
qualified domain name (FQDN) for the server: `anvil.ccmc.pw`.

This is the path of the LetsEncrypt/Certbot certificates. It is not
clear to me why this changed or how it broke suddenly, but this change
fixes the issue. At commit time, I ran this change into production and
verified it solved the issue.

cc: @JMW18