### PR TITLE
Change spigot version from 1.16.2 to 1.16.4

### DIFF
--- a/roles/spigot/defaults/main.yml
+++ b/roles/spigot/defaults/main.yml
@@ -5,5 +5,5 @@ linux:
   mem_usage: "4G"
 spigot:
   jar_path: "/usr/games/spigot/spigot.jar"
-  version: "1.16.2"
+  version: "1.16.4"
 server_path: "/var/games/spigot-server"


### PR DESCRIPTION
I made a change in the infrastructure/roles/defaults/main.yml file. We are now running 1.16.4 and will continue to use it for the near future.