### PR TITLE
system/user-management: Initial commit

### DIFF
--- a/playbooks/hosts/anvil.yml
+++ b/playbooks/hosts/anvil.yml
@@ -7,5 +7,6 @@
     - { role: system/firewalld, tags: ['firewalld', 'system'] }
     - { role: system/selinux, tags: ['selinux', 'system'] }
     - { role: system/sshd, tags: ['sshd', 'system'] }
+    - { role: system/user-management, tags: ['users', 'user-management', 'system'] }
     - { role: anvil.ccmc.pw, tags: ['anvil', 'apps'] }
-    - { role: spigot, tags: ['spigot', 'minecraft'] }
+    - { role: spigot, tags: ['spigot', 'minecraft', 'apps'] }

--- a/roles/system/user-management/README.md
+++ b/roles/system/user-management/README.md
@@ -1,0 +1,36 @@
+system/user-management
+======================
+
+User management and privilege-escalation configuration for a Spigot game server.
+
+
+Requirements
+------------
+
+This role adds a user management layer to the system configuration for a Spigot game server.
+Special privileges are given to members of the `spigot-admin` group to manage and access a wider subset of the system.
+In this case, the key objective is to allow the restarting of systemd services via `systemctl restart`.
+
+
+Role Variables
+--------------
+
+This role uses the inherited variable `{{ admin_uids }}` to create the user accounts for the admin users, if they do not already exist.
+
+
+Dependencies
+------------
+
+Depends on the [`spigot` role](https://github.com/CrystalCraftMC/infrastructure/tree/master/roles/spigot).
+
+
+License
+-------
+
+BSD-2-Clause
+
+
+Author Information
+------------------
+
+This role was created in 2021 by [Justin W. Flory](https://jwf.io/).

--- a/roles/system/user-management/files/10_spigot-admin
+++ b/roles/system/user-management/files/10_spigot-admin
@@ -1,0 +1,23 @@
+## Command Aliases
+## These are groups of related commands...
+
+## Networking
+Cmnd_Alias NETWORKING = /usr/sbin/route, /usr/sbin/ifconfig, /usr/sbin/ip, /usr/bin/ping, /usr/sbin/dhclient, /usr/bin/firewall-cmd, /usr/sbin/mii-tool
+
+## Installation and management of software
+Cmnd_Alias SOFTWARE = /usr/bin/dnf
+
+## Services
+Cmnd_Alias SERVICES = /usr/bin/systemctl start, /usr/bin/systemctl stop, /usr/bin/systemctl reload, /usr/bin/systemctl restart, /usr/bin/systemctl status, /usr/bin/systemctl enable, /usr/bin/systemctl disable, /usr/bin/systemctl daemon-reload
+
+## Storage
+Cmnd_Alias STORAGE = /usr/sbin/fdisk, /usr/sbin/sfdisk, /usr/sbin/parted, /usr/sbin/partprobe, /usr/bin/mount, /usr/bin/umount
+
+## Delegating permissions
+Cmnd_Alias DELEGATING = /usr/bin/chown, /usr/bin/chmod, /usr/bin/chgrp
+
+## Processes
+Cmnd_Alias PROCESSES = /usr/bin/nice, /usr/bin/kill, /usr/bin/killall
+
+## Allows members of the 'spigot-admin' group to run all above command alias groups.
+%spigot-admin	ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES

--- a/roles/system/user-management/meta/main.yml
+++ b/roles/system/user-management/meta/main.yml
@@ -1,0 +1,26 @@
+galaxy_info:
+  role_name: system/user-management
+  author: Justin W. Flory and CrystalCraftMC Community
+  description: User management and privilege-escalation configuration for a Spigot game server.
+  company: CrystalCraftMC
+  license: BSD-2-Clause
+  min_ansible_version: 2.9
+  galaxy_tags:
+    - linux
+    - sudo
+    - permissions
+    - minecraft
+    - spigot
+    - spigotmc
+    - gaming
+
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  platforms:
+    - name: EL
+      versions:
+        - 8
+
+  dependencies:
+    - spigot

--- a/roles/system/user-management/tasks/main.yml
+++ b/roles/system/user-management/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# tasks file for user-management
+- name: verify all admin UIDs exist and use a bash shell
+  user:
+    name: "{{ item }}"
+    shell: /usr/bin/bash
+  loop: "{{ admin_uids }}"
+
+- name: install custom sudoers.d file for %spigot-admins to administer system
+  copy:
+    src: 10_spigot-admin
+    dest: /etc/sudoers.d/10_spigot-admin
+    mode: 0640
+    setype: etc_t
+    seuser: system_u
+    validate: /usr/sbin/visudo --check --strict --file=%s


### PR DESCRIPTION
This commit adds a new role to manage users and privilege-escalation on
the Spigot game host. Most notably, it creates a custom sudoers policy
for the `spigot-admin` group and delegates specific privileges to all
members of the group.

This is a security hardening technique and clearly defines a policy for
Spigot game server admins. This also enables the possibility of adding
other sysadmins to the team at fairly low risk.

cc: @JMW18