### PR TITLE
Refactor privileged users logic

### DIFF
--- a/inventory/inventory
+++ b/inventory/inventory
@@ -4,7 +4,3 @@ all:
   hosts:
     anvil:
       ansible_host: anvil.ccmc.pw
-      admin_uids:
-        - blaster
-        - jmw
-        - jwf

--- a/roles/spigot/tasks/binaries.yml
+++ b/roles/spigot/tasks/binaries.yml
@@ -1,4 +1,12 @@
 ---
+- name: create Spigot server system user
+  user:
+    name: "{{ linux.mc_user }}"
+    comment: "system user for Spigot Minecraft servers - do not use"
+    create_home: no
+    home: "{{ server_path }}"
+    system: yes
+
 - name: create directory for Spigot user binaries
   file:
     state: directory

--- a/roles/spigot/tasks/main.yml
+++ b/roles/spigot/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 # tasks file for spigot
 - include_tasks: java.yml
-- include_tasks: user-management.yml
 - include_tasks: binaries.yml
 - include_tasks: server.yml

--- a/roles/spigot/tasks/user-management.yml
+++ b/roles/spigot/tasks/user-management.yml
@@ -1,15 +1,2 @@
 ---
-- name: create Spigot server system user
-  user:
-    name: "{{ linux.mc_user }}"
-    comment: "system user for Spigot Minecraft servers - do not use"
-    create_home: no
-    home: "{{ server_path }}"
-    system: yes
 
-- name: append spigot-admin group to admin users
-  user:
-    name: "{{ item }}"
-    groups: "{{ linux.mc_user }}"
-    append: yes
-  loop: "{{ admin_uids }}"

--- a/roles/system/user-management/README.md
+++ b/roles/system/user-management/README.md
@@ -16,6 +16,20 @@ Role Variables
 --------------
 
 This role uses the inherited variable `{{ admin_uids }}` to create the user accounts for the admin users, if they do not already exist.
+Lists of strings are used to elevate users to use privileged commands.
+`privileged.full_sudo` adds listed users to the `wheel` group, while `privileged.jr_sysadmins` adds users to the `spigot-admin` group.
+
+```yaml
+---
+privileged:
+  full_sudo:
+	- blaster
+	- jmw
+	- jwf
+  jr_sysadmins:
+  	- dinnerbone
+	- echophox
+```
 
 
 Dependencies

--- a/roles/system/user-management/files/10_spigot-admin
+++ b/roles/system/user-management/files/10_spigot-admin
@@ -1,23 +1,27 @@
-## Command Aliases
-## These are groups of related commands...
-
 ## Networking
-Cmnd_Alias NETWORKING = /usr/sbin/route, /usr/sbin/ifconfig, /usr/sbin/ip, /usr/bin/ping, /usr/sbin/dhclient, /usr/bin/firewall-cmd, /usr/sbin/mii-tool
+Cmnd_Alias NETWORKING = \
+	/usr/bin/firewall-cmd
 
 ## Installation and management of software
-Cmnd_Alias SOFTWARE = /usr/bin/dnf
+Cmnd_Alias PACKAGES = \
+	/usr/bin/dnf
+
+## System journals
+Cmnd_Alias JOURNALS = \
+	/usr/bin/journalctl * spigot-server.service
 
 ## Services
-Cmnd_Alias SERVICES = /usr/bin/systemctl start, /usr/bin/systemctl stop, /usr/bin/systemctl reload, /usr/bin/systemctl restart, /usr/bin/systemctl status, /usr/bin/systemctl enable, /usr/bin/systemctl disable, /usr/bin/systemctl daemon-reload
-
-## Storage
-Cmnd_Alias STORAGE = /usr/sbin/fdisk, /usr/sbin/sfdisk, /usr/sbin/parted, /usr/sbin/partprobe, /usr/bin/mount, /usr/bin/umount
-
-## Delegating permissions
-Cmnd_Alias DELEGATING = /usr/bin/chown, /usr/bin/chmod, /usr/bin/chgrp
+Cmnd_Alias SERVICES = \
+	/usr/bin/systemctl start	spigot-server.service, \
+	/usr/bin/systemctl stop 	spigot-server.service, \
+	/usr/bin/systemctl reload 	spigot-server.service, \
+	/usr/bin/systemctl restart 	spigot-server.service
 
 ## Processes
-Cmnd_Alias PROCESSES = /usr/bin/nice, /usr/bin/kill, /usr/bin/killall
+Cmnd_Alias PROCESSES = \
+	/usr/bin/nice, \
+	/usr/bin/kill, \
+	/usr/bin/killall
 
 ## Allows members of the 'spigot-admin' group to run all above command alias groups.
-%spigot-admin	ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES
+%spigot-admin	ALL = NETWORKING, PACKAGES, JOURNALS, SERVICES, PROCESSES

--- a/roles/system/user-management/tasks/main.yml
+++ b/roles/system/user-management/tasks/main.yml
@@ -1,10 +1,22 @@
 ---
 # tasks file for user-management
-- name: verify all admin UIDs exist and use a bash shell
+- name: append full_sudo users to spigot-admin and wheel groups and set Bash shell
   user:
     name: "{{ item }}"
     shell: /usr/bin/bash
-  loop: "{{ admin_uids }}"
+    append: yes
+    groups:
+      - spigot-admin
+      - wheel
+  loop: "{{ privileged.full_sudo }}"
+
+# Uncomment once real usernames are added to roles/system/user-management/vars/main.yml
+#- name: append jr_sysadmins users to spigot-admin group
+#  user:
+#    name: "{{ item }}"
+#    groups: spigot-admin
+#    append: yes
+#  loop: "{{ privileged.jr_sysadmins }}"
 
 - name: install custom sudoers.d file for %spigot-admins to administer system
   copy:

--- a/roles/system/user-management/vars/main.yml
+++ b/roles/system/user-management/vars/main.yml
@@ -1,0 +1,7 @@
+---
+privileged:
+  full_sudo:
+    - blaster
+    - jmw
+    - jwf
+  jr_sysadmins: []


### PR DESCRIPTION
This commit reworks how the privileged user logic works. The changes are
best summarized below:

* Move user account creation and group membership changes to
  `system/user-management` role instead of `spigot` role
* Move `admin_uids` from an inventory-defined list of variables to a
  role-defined list of variables (`privileged.{full_sudo,jr_sysadmins}`)
* Add `blaster` and `jmw` to `wheel` group
* Change custom sudoer rule file to specify systemctl commands for
  spigot-server.service and narrow down privileges useful in the context
  of running a Minecraft server