### PR TITLE
repos/epel: No longer require CentOS PowerTools repo

### DIFF
--- a/roles/repos/epel/tasks/main.yml
+++ b/roles/repos/epel/tasks/main.yml
@@ -5,15 +5,6 @@
     name: epel-release
   when: ansible_facts['distribution'] == "CentOS"
 
-- name: enable CentOS PowerTools repository (for certbot)
-  lineinfile:
-    path: /etc/yum.repos.d/CentOS-PowerTools.repo
-    regexp: '^enabled='
-    line: "enabled=1"
-  when:
-    - ansible_facts['os_family'] == "RedHat"
-    - ansible_facts['distribution_major_version'] == "8"
-
 - name: install base EPEL packages
   package:
     state: present


### PR DESCRIPTION
Anvil was upgraded to CentOS Stream. In CentOS Stream, the PowerTools
repo seems no longer necessary. It causes the playbook run to fail. This
fixes the error by deleting the unnecessary task.